### PR TITLE
fix indentation to correct extras page paths

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -59,7 +59,7 @@ collections:
     permalink: /:path/index.html
   extras:
     output: true
-permalink: /:path/index.html
+    permalink: /:path/index.html
 
 # Set the default layout for things in the episodes collection.
 defaults:
@@ -77,7 +77,7 @@ defaults:
       type: extras
     values:
       root: ..
-layout: page
+      layout: page
 
 # Files and directories that are not to be copied.
 exclude:


### PR DESCRIPTION
The link to the [Instructor Notes page for this lesson](https://librarycarpentry.org/lc-webscraping/extras/guide) is broken from https://librarycarpentry.org/lessons/. I found this was because of some missed indentation where the Extras collection is set up in `_config.yml`. This PR fixes that indentation and makes the paths to your Extras pages consistent with other lessons. This should fix the broken link form the LC website.