### PR TITLE
Replace dead link image with local host one

### DIFF
--- a/_episodes/02-xpath.md
+++ b/_episodes/02-xpath.md
@@ -567,7 +567,7 @@ XPath Axes fuller syntax of how to use XPath. Provides all of the different ways
 * following ‐‐ all following nodes in the document, excluding descendants
 * preceding ‐‐ all preceding nodes in the document, excluding ancestors • attribute ‐‐ the attributes of the context node
 
-[![XPath Axes Image Credit: SAMS Teach Yourself XSLT in 21 Days](https://kimpham54.github.io/library-webscraping/fig/xpath-axes.jpg)]({{ page.root }}/fig/xpath-axes.jpg)
+[![XPath Axes Image Credit: SAMS Teach Yourself XSLT in 21 Days]({{ page.root }}/fig/xpath-axes.jpg)]({{ page.root }}/fig/xpath-axes.jpg)
 
 
 |Path Expression|	Result|


### PR DESCRIPTION
In the XPath Axes section, there is an image included whose source is on another site and no longer exists: https://kimpham54.github.io/library-webscraping/fig/xpath-axes.jpg
 The image is surrounded by a link to a local copy of the same image. I have confirmed it is the same image by checking the Wayback Machine. I have replaced the image source with the local image. Not sure if there is a need to keep the surrounding link because the image is the same size wherever viewed.