### PR TITLE
Typo and bad link to Support page

### DIFF
--- a/_episodes/03-manual-scraping.md
+++ b/_episodes/03-manual-scraping.md
@@ -22,8 +22,8 @@ Now we are finally ready to do some web scraping. Let's go back to the list of M
 the [Legislative Assembly of Ontario](https://www.ola.org/en/members/current).
 
 We are interested in downloading this list to a spreadsheet, with columns for names and
-constituencies. Do do so, we will use the Scraper extension in the Chrome browser
-(refer to the [Setup](setup/) section for help installing these tools).
+constituencies. To do so, we will use the Scraper extension in the Chrome browser
+(refer to the [Setup]({{ page.root }}/setup.html) section for help installing these tools).
 
 ## Scrape similar
 


### PR DESCRIPTION
Fixed minor typo (Do/To). Fixed link to Support page.
