### PR TITLE
Remove incomplete Additions section until final

### DIFF
--- a/_episodes/02-xpath.md
+++ b/_episodes/02-xpath.md
@@ -590,17 +590,6 @@ $x("//h2[@id='navigating-through-the-html-node-tree-using-xpath']/following-sibl
 ~~~
 {: .source}
 
-
-# Additions
-
-FIXME: add more XPath functions such as concat() and normalize-space().
-FIXME: mention [XPath Checker for Firefox](https://addons.mozilla.org/en-US/firefox/addon/xpath-checker/)
-FIXME: Firefox sometime cleans up the HTML of a page before displaying it, meaning that the DOM tree
-we can access through the console might not reflect the actual source code. `<tbody>` elements are
-typically not reliable.
-The [Scrapy documentation](https://doc.scrapy.org/en/latest/topics/firefox.html#caveats-with-inspecting-the-live-browser-dom)
-has more on the topic. 
-
 # References
 
 * [W3Schools: JavaScript HTML DOM Navigation](http://www.w3schools.com/js/js_htmldom_navigation.asp)


### PR DESCRIPTION
Removes the "Additions" heading and text under it containing multiple FIXMEs that were presumably never meant to be public-facing. Opening separate issue with the original text so decisions can be made later on what to do with section permanently.